### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,7 +68,7 @@ def notify():
         return jsonify({'ok': True})
     except Exception as e:
         logging.exception("Email send failed")
-        return jsonify({'ok': False, 'error': str(e)}), 500
+        return jsonify({'ok': False, 'error': 'An internal error has occurred'}), 500
 
 @app.get('/healthz')
 def health():


### PR DESCRIPTION
Potential fix for [https://github.com/miguelgalvarez/ESFEST-inventory.io/security/code-scanning/2](https://github.com/miguelgalvarez/ESFEST-inventory.io/security/code-scanning/2)

To fix the problem, we should avoid returning the exception message (`str(e)`) to the client. Instead, we should return a generic error message, such as "An internal error has occurred" or similar, while continuing to log the full exception details on the server for debugging purposes. The change should be made in the exception handler in the `/` POST endpoint (lines 69-71 in app.py). No new methods are needed, but the error message in the response should be replaced with a generic one. No new imports are required, as logging is already used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
