### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,7 +71,7 @@ def notify():
         return jsonify({'ok': True})
     except Exception as e:
         logging.exception("Email send failed")
-        return jsonify({'ok': False, 'error': str(e)}), 500
+        return jsonify({'ok': False, 'error': 'An internal error has occurred'}), 500
 
 def send_email(room: str, material: str):
     if not (SMTP_USER and (SMTP_PASS or SMTP_PORT == 25) and MAIL_TO):


### PR DESCRIPTION
Potential fix for [https://github.com/miguelgalvarez/ESFEST-inventory.io/security/code-scanning/3](https://github.com/miguelgalvarez/ESFEST-inventory.io/security/code-scanning/3)

To resolve the problem, modify the error handling in the `/` notification route so that the detailed exception message is *not* returned to the client. Instead, return a generic error message such as `"An internal error has occurred"` while logging the exception (or stack trace) on the server for developer reference. Specifically, change line 74 to:

```python
return jsonify({'ok': False, 'error': 'An internal error has occurred'}), 500
```

The logging on line 73 (`logging.exception("Email send failed")`) already logs the stack trace for developers, so no further logging changes are needed. No new methods or imports are necessary, as `logging` is already imported and used.

Edit only the except block of the `notify()` method in app.py to replace the exposure of exception details with a generic error message.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
